### PR TITLE
🐛 FavoriteSchedule

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,13 +39,26 @@ function App() {
   useEffect(() => {
     document.documentElement.classList.remove("dark");
     document.documentElement.classList.add("light");
-    const access = localStorage.getItem("access_token");
-    const refresh = localStorage.getItem("refresh_token");
-    const userInfo = JSON.parse(localStorage.getItem("user_info"));
+
+    const access = localStorage.getItem("accessToken");
+    const refresh = localStorage.getItem("refreshToken");
+    const userInfo = localStorage.getItem("user_info");
+
     if (access && refresh && userInfo) {
-      useUserStore.getState().login(userInfo, access, refresh);
+      try {
+        const parsedUser = JSON.parse(userInfo);
+        useUserStore.getState().login(parsedUser, access, refresh);
+      } catch (e) {
+        console.warn("🧹 유저 정보 파싱 실패. 로컬스토리지 초기화");
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("refreshToken");
+        localStorage.removeItem("user_info");
+      }
+    } else {
+      localStorage.removeItem("accessToken");
+      localStorage.removeItem("refreshToken");
+      localStorage.removeItem("user_info");
     }
-    
   }, []);
 
   useEffect(() => {

--- a/src/components/ScheduleList.jsx
+++ b/src/components/ScheduleList.jsx
@@ -1,21 +1,24 @@
 import React, { useEffect, useState } from "react";
+import useUserStore from "../store/userStore";
+import { fetchFavoriteSchedules } from "../api/schedule/scheduleApi";
 import ScheduleListItem from "./ScheduleListItem";
 import { fetchAllSchedules } from "../api/schedule/scheduleApi";
 
 const ScheduleList = () => {
+  const { user } = useUserStore();
   const [schedules, setSchedules] = useState([]);
 
   useEffect(() => {
     const loadSchedules = async () => {
       try {
-        const data = await fetchAllSchedules();
+        const data = user ? await fetchFavoriteSchedules() : await fetchAllSchedules();
         setSchedules(data);
       } catch (error) {
         console.error("❌ 일정 불러오기 실패:", error);
       }
     };
     loadSchedules();
-  }, []);
+  }, [user]);
 
   if (schedules.length === 0) return <div>일정이 없습니다.</div>;
 


### PR DESCRIPTION
메인페이지스케줄 즐겨찾기누르면 스케줄창에 추가됨
반대로 스케줄페이지에 추가된 즐겨찾기 스케줄 클릭시 즐겨찾기 삭제 추가해야함
++++

<app.jsx> 
Fix: 앱 진입 시 로컬스토리지에 저장된 사용자 정보 파싱 오류 방지 로직 추가
- accessToken, refreshToken, user_info 값이 유효하지 않을 경우 로컬스토리지 초기화
- JSON 파싱 실패에 대한 예외 처리 추가
- 앱 진입 시 사용자 인증 상태를 안정적으로 복원

이제 쿠키 초기화 안해도 될듯 아마도?